### PR TITLE
fix: use persistent flags for --profile and --read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Interactive AWS SSO (Identity Center) login CLI with automatic profile generatio
 ## Installation
 
 ```bash
+# Homebrew
+brew install Photosynth-inc/tap/aws-sso-login
+
+# Go
 go install github.com/Photosynth-inc/aws-sso-login/cmd/aws-sso-login@latest
 ```
 

--- a/cmd/aws-sso-login/main.go
+++ b/cmd/aws-sso-login/main.go
@@ -70,18 +70,6 @@ func main() {
 				Name:   "login",
 				Usage:  "Login to AWS SSO interactively",
 				Action: handleLogin,
-				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:    "profile",
-						Aliases: []string{"p"},
-						Usage:   "AWS profile name",
-					},
-					&cli.BoolFlag{
-						Name:    "read-only",
-						Aliases: []string{"ro"},
-						Usage:   "Use ReadOnly profile (auto-select -ro suffix)",
-					},
-				},
 			},
 			{
 				Name:    "sync",
@@ -133,13 +121,6 @@ func main() {
 				Name:   "status",
 				Usage:  "Show session status",
 				Action: handleStatus,
-				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:    "profile",
-						Aliases: []string{"p"},
-						Usage:   "AWS profile name (default: current AWS_PROFILE)",
-					},
-				},
 			},
 		},
 		Action: handleDefault,


### PR DESCRIPTION
## Summary

- Move `--profile` / `--read-only` flags from login/status subcommands to root command
- urfave/cli v3 persistent flag propagation makes them available to all subcommands
- Fixes: `aws-sso-login -ro` now works without specifying `login` subcommand
- Add Homebrew install instructions to README

## Test Plan

- [x] `aws-sso-login -ro` no longer errors with "flag provided but not defined"
- [x] `aws-sso-login login --help` shows `--profile` and `--read-only` under GLOBAL OPTIONS
- [x] `aws-sso-login status --help` shows `--profile` under GLOBAL OPTIONS