### PR TITLE
feat: add --force flag to login command for forced re-authentication

### DIFF
--- a/cmd/aws-sso-login/actions.go
+++ b/cmd/aws-sso-login/actions.go
@@ -97,16 +97,18 @@ func handleLogin(ctx context.Context, c *cli.Command) error {
 		return fmt.Errorf("cannot determine SSO start URL. Use --sso-start-url or configure profiles first")
 	}
 
-	// Check if already authenticated
-	if token, err := sso.GetTokenForStartURL(ssoStartURL); err == nil {
-		if opts.JSON {
-			return emitJSON(LoginResult{
-				StartURL:  ssoStartURL,
-				ExpiresAt: token.ExpiresAt.Format("2006-01-02T15:04:05Z"),
-			})
+	// Check if already authenticated (skip when --force is specified)
+	if !c.Bool("force") {
+		if token, err := sso.GetTokenForStartURL(ssoStartURL); err == nil {
+			if opts.JSON {
+				return emitJSON(LoginResult{
+					StartURL:  ssoStartURL,
+					ExpiresAt: token.ExpiresAt.Format("2006-01-02T15:04:05Z"),
+				})
+			}
+			fmt.Printf("✓ Already authenticated (expires: %s)\n", token.ExpiresAt.Format("2006-01-02 15:04:05"))
+			return nil
 		}
-		fmt.Printf("✓ Already authenticated (expires: %s)\n", token.ExpiresAt.Format("2006-01-02 15:04:05"))
-		return nil
 	}
 
 	if opts.JSON {

--- a/cmd/aws-sso-login/main.go
+++ b/cmd/aws-sso-login/main.go
@@ -80,6 +80,11 @@ func main() {
 						Usage: "SSO region",
 						Value: "ap-northeast-1",
 					},
+					&cli.BoolFlag{
+						Name:    "force",
+						Aliases: []string{"f"},
+						Usage:   "Force re-authentication even if a valid session exists",
+					},
 				},
 			},
 			{


### PR DESCRIPTION
## Problem

`login` and `status` commands use different methods to verify session validity, leading to inconsistent results.

| Command | Check method |
|---------|-------------|
| `login` | Token file expiry in `~/.aws/sso/cache/` (local check) |
| `status` | Actually runs `aws sts get-caller-identity` (remote check) |

This difference caused the following contradiction:

\`\`\`
❯ aws-sso-login login
✓ Already authenticated (expires: 2026-02-25 10:25:22)

❯ aws-sso-login status --profile photosynth-dev
Status: ✗ Invalid or expired
Error: session is invalid or expired
\`\`\`

This occurs when the local token is within its expiry but the actual API call fails (e.g., profile misconfiguration, expired role credentials).

## Fix

Added `--force` / `-f` flag to the `login` command.

\`\`\`bash
# Force re-authentication (skip existing session and trigger browser login)
aws-sso-login login --force
aws-sso-login login -f

# status should return Valid afterwards
aws-sso-login status --profile photosynth-dev
\`\`\`

## Changes

- `main.go`: Define `--force` / `-f` flag on the `login` command
- `actions.go`: Skip cached token check and force browser login when `--force` is specified

## Test plan

- [ ] Verify `aws-sso-login login` returns "Already authenticated" when a valid session exists
- [ ] Verify `aws-sso-login login --force` triggers browser login even when a valid session exists
- [ ] Verify `-f` shorthand works the same way
- [ ] Verify `aws-sso-login status --profile <profile>` returns Valid after `--force` login