### PR TITLE
chore: add golangci-lint v2.11.3 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,3 +31,8 @@ jobs:
         run: |
           go fmt ./...
           git diff --exit-code
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.11.3

--- a/cmd/aws-sso-login/commandrules.go
+++ b/cmd/aws-sso-login/commandrules.go
@@ -70,11 +70,6 @@ func lookupCommandRule(cmd string) *CommandRule {
 	return commandRuleMap[base]
 }
 
-// isFirstClassCommand returns true if the command is recognized by the rule table.
-func isFirstClassCommand(cmd string) bool {
-	return lookupCommandRule(cmd) != nil
-}
-
 // firstClassCommandNames returns all registered command names for quickHit.
 func firstClassCommandNames() []string {
 	names := make([]string, 0, len(commandRuleMap))
@@ -88,16 +83,6 @@ func firstClassCommandNames() []string {
 func hasFlag(args []string, flag string) bool {
 	for _, a := range args {
 		if a == flag {
-			return true
-		}
-	}
-	return false
-}
-
-// hasFlagPrefix checks if any element in args starts with the given prefix.
-func hasFlagPrefix(args []string, prefix string) bool {
-	for _, a := range args {
-		if strings.HasPrefix(a, prefix) {
 			return true
 		}
 	}

--- a/cmd/aws-sso-login/save.go
+++ b/cmd/aws-sso-login/save.go
@@ -160,7 +160,7 @@ func appendToConfig(configPath, content string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open config: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if _, err := f.WriteString("\n" + content); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)

--- a/internal/sso/generator.go
+++ b/internal/sso/generator.go
@@ -262,21 +262,21 @@ func FormatAsINI(profiles []ProfileTemplate) string {
 	sb.WriteString("# " + fmt.Sprintf("%d profiles\n\n", len(profiles)))
 
 	for _, p := range profiles {
-		sb.WriteString(fmt.Sprintf("[profile %s]\n", p.Name))
-		sb.WriteString(fmt.Sprintf("sso_session = %s\n", p.SSOSession))
-		sb.WriteString(fmt.Sprintf("sso_account_id = %s\n", p.AccountID))
-		sb.WriteString(fmt.Sprintf("sso_role_name = %s\n", p.RoleName))
-		sb.WriteString(fmt.Sprintf("region = %s\n", p.Region))
-		sb.WriteString(fmt.Sprintf("output = %s\n", p.Output))
+		fmt.Fprintf(&sb, "[profile %s]\n", p.Name)
+		fmt.Fprintf(&sb, "sso_session = %s\n", p.SSOSession)
+		fmt.Fprintf(&sb, "sso_account_id = %s\n", p.AccountID)
+		fmt.Fprintf(&sb, "sso_role_name = %s\n", p.RoleName)
+		fmt.Fprintf(&sb, "region = %s\n", p.Region)
+		fmt.Fprintf(&sb, "output = %s\n", p.Output)
 		sb.WriteString("\n")
 	}
 
 	// Add SSO session configuration
 	if len(profiles) > 0 {
 		p := profiles[0]
-		sb.WriteString(fmt.Sprintf("[sso-session %s]\n", p.SSOSession))
-		sb.WriteString(fmt.Sprintf("sso_start_url = %s\n", p.SSOStartURL))
-		sb.WriteString(fmt.Sprintf("sso_region = %s\n", p.SSORegion))
+		fmt.Fprintf(&sb, "[sso-session %s]\n", p.SSOSession)
+		fmt.Fprintf(&sb, "sso_start_url = %s\n", p.SSOStartURL)
+		fmt.Fprintf(&sb, "sso_region = %s\n", p.SSORegion)
 		sb.WriteString("sso_registration_scopes = sso:account:access\n")
 	}
 


### PR DESCRIPTION
## Summary

- Add `golangci-lint` v2.11.3 step to CI workflow
- Fix all 6 lint issues found:
  - `errcheck`: unchecked `f.Close()` in `save.go`
  - `staticcheck` (x3): `WriteString(fmt.Sprintf(...))` → `fmt.Fprintf(...)` in `generator.go`
  - `unused` (x2): remove dead code `isFirstClassCommand` and `hasFlagPrefix` in `commandrules.go`

## Test plan

- [x] `golangci-lint run ./...` → 0 issues
- [x] All tests pass