### PR TITLE
fix(guard): prevent dynamic args from being misidentified as --profile flag

### DIFF
--- a/cmd/aws-sso-login/shellanalyze.go
+++ b/cmd/aws-sso-login/shellanalyze.go
@@ -496,9 +496,13 @@ func wordStatic(w *syntax.Word) (string, bool) {
 // wordHasPrefix reports whether the accumulated static prefix of a Word starts
 // with the given prefix. It concatenates consecutive literal parts until a
 // dynamic part is reached, then checks conservatively: if the accumulated static
-// part is itself a prefix of the target prefix (could still become --profile=
-// after dynamic expansion), it returns true. This handles `"--profile=$P"` and
-// `"--pro${X}file=$P"`.
+// part is itself a non-empty prefix of the target prefix (could still become
+// --profile= after dynamic expansion), it returns true. This handles
+// `"--profile=$P"` and `"--pro${X}file=$P"`.
+//
+// When the accumulated static prefix is empty and a dynamic part is encountered,
+// we cannot infer anything — the word could expand to anything, but we should
+// not treat it as matching an arbitrary prefix.
 func wordHasPrefix(w *syntax.Word, prefix string) bool {
 	var b strings.Builder
 	for _, part := range w.Parts {
@@ -512,15 +516,13 @@ func wordHasPrefix(w *syntax.Word, prefix string) bool {
 				lit, ok := inner.(*syntax.Lit)
 				if !ok {
 					acc := b.String()
-					// Conservative: if what we have so far is a prefix of the target
-					// (meaning dynamic content could complete it), report a match.
-					return strings.HasPrefix(acc, prefix) || strings.HasPrefix(prefix, acc)
+					return strings.HasPrefix(acc, prefix) || (len(acc) > 0 && strings.HasPrefix(prefix, acc))
 				}
 				b.WriteString(lit.Value)
 			}
 		default:
 			acc := b.String()
-			return strings.HasPrefix(acc, prefix) || strings.HasPrefix(prefix, acc)
+			return strings.HasPrefix(acc, prefix) || (len(acc) > 0 && strings.HasPrefix(prefix, acc))
 		}
 	}
 	return strings.HasPrefix(b.String(), prefix)

--- a/cmd/aws-sso-login/shellanalyze_test.go
+++ b/cmd/aws-sso-login/shellanalyze_test.go
@@ -122,6 +122,10 @@ func TestAnalyzeCommand(t *testing.T) {
 		// command substitution: aws inside $() is analyzed
 		{"echo $(aws s3 ls --profile prod)", VerdictBlock},
 		{"echo $(aws s3 ls --profile prod-ro)", VerdictAllow},
+
+		// dynamic args (e.g. $(date ...)) must not be mistaken for --profile
+		{"AWS_PROFILE=prod-ro aws s3 ls $(echo foo)", VerdictAllow},
+		{`AWS_PROFILE=prod-ro aws cloudtrail lookup-events --start-time $(date -u) --region ap-northeast-1`, VerdictAllow},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `wordHasPrefix` returned true for any Word starting with a dynamic part (CmdSubst, ParamExp, etc.) because `strings.HasPrefix(prefix, "")` is always true
- This caused commands like `AWS_PROFILE=prod-ro aws cloudtrail ... --start-time $(date -u)` to be blocked with "profile value is dynamic" even though the profile was statically known
- Added `len(acc) > 0` guard so an empty static prefix is not treated as a potential match for the target prefix

## Test plan
- [x] All existing tests pass
- [x] `AWS_PROFILE=prod-ro aws s3 ls $(echo foo)` → VerdictAllow
- [x] `AWS_PROFILE=prod-ro aws cloudtrail lookup-events --start-time $(date -u) --region ap-northeast-1` → VerdictAllow
- [x] `aws s3 ls "--profile=$P"` → VerdictUnknown (existing dynamic --profile detection preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)