### PR TITLE
feat: add headless SSO login flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ go.work
 # OS
 .DS_Store
 Thumbs.db
+
+# cache
+.gocache/
+.gomodcache/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Interactive AWS SSO (Identity Center) login CLI with automatic profile generatio
 - **Interactive profile selection** - Choose AWS profiles with fuzzy search
 - **Auto-generate profiles** - Create profiles from Identity Center (known roles auto-detected, custom roles via `--include-roles`)
 - **Session management** - Check login status and expiration
+- **Headless login** - Skip browser auto-open and complete device auth manually
 - **ReadOnly mode** - Safe account investigation with read-only access
 - **Scoped credentials** - Export temporary credentials for a specific role via `creds`
 
@@ -24,7 +25,7 @@ go install github.com/Photosynth-inc/aws-sso-login/cmd/aws-sso-login@latest
 
 | Command | Purpose |
 |---------|---------|
-| `login` (default) | Authenticate to AWS SSO (browser flow only) |
+| `login` (default) | Authenticate to AWS SSO (browser or headless device flow) |
 | `use` | Select a profile and export `AWS_PROFILE` |
 | `creds` | Get scoped temporary credentials via `GetRoleCredentials` API |
 | `sync` | Generate profiles from Identity Center |
@@ -45,6 +46,17 @@ aws-sso-login login
 
 # Explicit start URL
 aws-sso-login login --sso-start-url https://your-domain.awsapps.com/start/
+
+# Headless: print the verification URL instead of opening a browser
+aws-sso-login login --headless
+```
+
+`--headless` also works on flows that auto-login, for example:
+
+```bash
+aws-sso-login use myapp-dev --headless
+aws-sso-login creds myapp-dev-ro --headless
+aws-sso-login sync --headless --dry-run
 ```
 
 ### use

--- a/cmd/aws-sso-login/actions.go
+++ b/cmd/aws-sso-login/actions.go
@@ -16,6 +16,13 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+var (
+	runSSOLogin         = sso.RunSSOLogin
+	getTokenForStartURL = sso.GetTokenForStartURL
+	getLatestToken      = sso.GetLatestToken
+	validateToken       = sso.ValidateToken
+)
+
 // --- JSON result types ---
 
 type LoginResult struct {
@@ -61,6 +68,12 @@ type SyncProfileItem struct {
 	Name      string `json:"name"`
 	AccountID string `json:"accountId"`
 	RoleName  string `json:"roleName"`
+}
+
+func loginOptions(c *cli.Command) sso.LoginOptions {
+	return sso.LoginOptions{
+		OpenBrowser: !c.Bool("headless"),
+	}
 }
 
 // --- login (auth-only) ---
@@ -111,8 +124,8 @@ func handleLogin(ctx context.Context, c *cli.Command) error {
 
 	// Check if already authenticated (skip when --force is specified)
 	if !c.Bool("force") {
-		if token, err := sso.GetTokenForStartURL(ssoStartURL); err == nil {
-			if validateErr := sso.ValidateToken(ctx, token.AccessToken, ssoRegion); validateErr == nil {
+		if token, err := getTokenForStartURL(ssoStartURL); err == nil {
+			if validateErr := validateToken(ctx, token.AccessToken, ssoRegion); validateErr == nil {
 				if opts.JSON {
 					return emitJSON(LoginResult{
 						StartURL:  ssoStartURL,
@@ -131,11 +144,11 @@ func handleLogin(ctx context.Context, c *cli.Command) error {
 	}
 
 	// Trigger browser login
-	if err := sso.RunSSOLogin(ctx, ssoStartURL, ssoRegion, ssoSession); err != nil {
+	if err := runSSOLogin(ctx, ssoStartURL, ssoRegion, ssoSession, loginOptions(c)); err != nil {
 		return fmt.Errorf("SSO login failed: %w", err)
 	}
 
-	token, err := sso.GetTokenForStartURL(ssoStartURL)
+	token, err := getTokenForStartURL(ssoStartURL)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve token after login: %w", err)
 	}
@@ -201,13 +214,13 @@ func handleUse(ctx context.Context, c *cli.Command) error {
 	startURL := cfg.ResolveStartURL(selectedProfile)
 	ssoRegion := cfg.ResolveRegion(selectedProfile)
 	if startURL != "" {
-		if _, tokenErr := sso.GetTokenForStartURL(startURL); tokenErr != nil {
-			if fallbackToken, fallbackErr := sso.GetLatestToken(); fallbackErr != nil {
+		if _, tokenErr := getTokenForStartURL(startURL); tokenErr != nil {
+			if fallbackToken, fallbackErr := getLatestToken(); fallbackErr != nil {
 				if opts.JSON {
 					return fmt.Errorf("no valid SSO session. Run 'aws-sso-login login' first")
 				}
 				logInfo("No valid SSO session. Starting login...")
-				if loginErr := sso.RunSSOLogin(ctx, startURL, ssoRegion, selectedProfile.SSOSession); loginErr != nil {
+				if loginErr := runSSOLogin(ctx, startURL, ssoRegion, selectedProfile.SSOSession, loginOptions(c)); loginErr != nil {
 					return fmt.Errorf("SSO login failed: %w", loginErr)
 				}
 			} else if fallbackToken.StartURL != startURL {
@@ -263,20 +276,20 @@ func handleCreds(ctx context.Context, c *cli.Command) error {
 
 	// Resolve SSO token
 	var token *sso.CachedToken
-	token, err = sso.GetTokenForStartURL(startURL)
+	token, err = getTokenForStartURL(startURL)
 	if err != nil {
-		token, err = sso.GetLatestToken()
+		token, err = getLatestToken()
 		if err != nil {
 			if opts.JSON || c.String("format") == "json" {
 				return fmt.Errorf("no valid SSO session. Run 'aws-sso-login login' first")
 			}
 			logInfo("No valid SSO session. Starting login...")
-			if loginErr := sso.RunSSOLogin(ctx, startURL, ssoRegion, profile.SSOSession); loginErr != nil {
+			if loginErr := runSSOLogin(ctx, startURL, ssoRegion, profile.SSOSession, loginOptions(c)); loginErr != nil {
 				return fmt.Errorf("SSO login failed: %w", loginErr)
 			}
-			token, err = sso.GetTokenForStartURL(startURL)
+			token, err = getTokenForStartURL(startURL)
 			if err != nil {
-				token, err = sso.GetLatestToken()
+				token, err = getLatestToken()
 				if err != nil {
 					return fmt.Errorf("failed to get SSO token after login: %w", err)
 				}
@@ -445,21 +458,21 @@ func handleSync(ctx context.Context, c *cli.Command) error {
 	var token *sso.CachedToken
 	var err error
 
-	token, err = sso.GetTokenForStartURL(ssoStartURL)
+	token, err = getTokenForStartURL(ssoStartURL)
 	if err != nil {
-		token, err = sso.GetLatestToken()
+		token, err = getLatestToken()
 		if err != nil {
 			// In --json mode, never trigger interactive browser login
 			if opts.JSON {
 				return fmt.Errorf("no valid SSO session found. Run 'aws-sso-login login' first")
 			}
 			logInfo("No valid SSO session found. Starting SSO login...")
-			if loginErr := sso.RunSSOLogin(ctx, ssoStartURL, ssoRegion, ssoSession); loginErr != nil {
+			if loginErr := runSSOLogin(ctx, ssoStartURL, ssoRegion, ssoSession, loginOptions(c)); loginErr != nil {
 				return fmt.Errorf("SSO login failed: %w", loginErr)
 			}
-			token, err = sso.GetTokenForStartURL(ssoStartURL)
+			token, err = getTokenForStartURL(ssoStartURL)
 			if err != nil {
-				token, err = sso.GetLatestToken()
+				token, err = getLatestToken()
 				if err != nil {
 					return fmt.Errorf("failed to get SSO token after login: %w", err)
 				}

--- a/cmd/aws-sso-login/actions_login_test.go
+++ b/cmd/aws-sso-login/actions_login_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Photosynth-inc/aws-sso-login/internal/sso"
+)
+
+func TestLoginHeadlessDisablesBrowserOpen(t *testing.T) {
+	restore := stubLoginDependencies(t)
+	defer restore()
+
+	var gotOpts sso.LoginOptions
+	loginCalled := false
+	runSSOLogin = func(ctx context.Context, ssoStartURL, ssoRegion, ssoSession string, opts sso.LoginOptions) error {
+		gotOpts = opts
+		loginCalled = true
+		return nil
+	}
+	getTokenForStartURL = func(startURL string) (*sso.CachedToken, error) {
+		if loginCalled {
+			return &sso.CachedToken{
+				AccessToken: "token",
+				ExpiresAt:   time.Now().Add(time.Hour),
+				StartURL:    startURL,
+			}, nil
+		}
+		return nil, fmt.Errorf("missing token")
+	}
+	validateToken = func(context.Context, string, string) error {
+		return fmt.Errorf("invalid")
+	}
+
+	writeAWSConfig(t, `
+[sso-session corp]
+sso_start_url = https://example.awsapps.com/start/
+sso_region = ap-northeast-1
+`)
+
+	cmd := newCommand()
+	err := cmd.Run(context.Background(), []string{"aws-sso-login", "login", "--headless"})
+
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if gotOpts.OpenBrowser {
+		t.Fatal("expected headless login to disable browser auto-open")
+	}
+}
+
+func TestUseHeadlessPropagatesToAutoLogin(t *testing.T) {
+	restore := stubLoginDependencies(t)
+	defer restore()
+
+	var gotOpts sso.LoginOptions
+	runSSOLogin = func(ctx context.Context, ssoStartURL, ssoRegion, ssoSession string, opts sso.LoginOptions) error {
+		gotOpts = opts
+		return nil
+	}
+	getTokenForStartURL = func(string) (*sso.CachedToken, error) {
+		return nil, fmt.Errorf("missing token")
+	}
+	getLatestToken = func() (*sso.CachedToken, error) {
+		return nil, fmt.Errorf("missing token")
+	}
+
+	writeAWSConfig(t, `
+[sso-session corp]
+sso_start_url = https://example.awsapps.com/start/
+sso_region = ap-northeast-1
+
+[profile sandbox-admin]
+sso_session = corp
+sso_account_id = 123456789012
+sso_role_name = AdministratorAccess
+region = ap-northeast-1
+output = json
+`)
+
+	cmd := newCommand()
+	err := cmd.Run(context.Background(), []string{"aws-sso-login", "use", "sandbox-admin", "--headless", "--export"})
+
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if gotOpts.OpenBrowser {
+		t.Fatal("expected headless use flow to disable browser auto-open")
+	}
+}
+
+func stubLoginDependencies(t *testing.T) func() {
+	t.Helper()
+
+	origRunSSOLogin := runSSOLogin
+	origGetTokenForStartURL := getTokenForStartURL
+	origGetLatestToken := getLatestToken
+	origValidateToken := validateToken
+	origHome := os.Getenv("HOME")
+
+	return func() {
+		runSSOLogin = origRunSSOLogin
+		getTokenForStartURL = origGetTokenForStartURL
+		getLatestToken = origGetLatestToken
+		validateToken = origValidateToken
+		_ = os.Setenv("HOME", origHome)
+	}
+}
+
+func writeAWSConfig(t *testing.T, content string) string {
+	t.Helper()
+
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".aws", "config")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Setenv("HOME", home); err != nil {
+		t.Fatalf("Setenv: %v", err)
+	}
+	return home
+}

--- a/cmd/aws-sso-login/main.go
+++ b/cmd/aws-sso-login/main.go
@@ -40,7 +40,23 @@ func emitJSON(v any) error {
 func main() {
 	ctx := context.Background()
 
-	cmd := &cli.Command{
+	cmd := newCommand()
+
+	if err := cmd.Run(ctx, os.Args); err != nil {
+		var exitErr *ExitError
+		if errors.As(err, &exitErr) {
+			if !exitErr.Silent {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", exitErr.Err)
+			}
+			os.Exit(exitErr.Code)
+		}
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func newCommand() *cli.Command {
+	return &cli.Command{
 		Name:    "aws-sso-login",
 		Usage:   "Interactive AWS SSO (Identity Center) login CLI",
 		Version: version,
@@ -64,11 +80,15 @@ func main() {
 				Aliases: []string{"ro"},
 				Usage:   "Use ReadOnly profile (auto-select -ro suffix)",
 			},
+			&cli.BoolFlag{
+				Name:  "headless",
+				Usage: "Do not auto-open a browser; print the device authorization URL and wait",
+			},
 		},
 		Commands: []*cli.Command{
 			{
 				Name:   "login",
-				Usage:  "Authenticate to AWS SSO (browser flow only, no profile selection)",
+				Usage:  "Authenticate to AWS SSO (browser or headless device flow, no profile selection)",
 				Action: handleLogin,
 				Flags: []cli.Flag{
 					&cli.StringFlag{
@@ -188,18 +208,6 @@ func main() {
 			},
 		},
 		Action: handleDefault,
-	}
-
-	if err := cmd.Run(ctx, os.Args); err != nil {
-		var exitErr *ExitError
-		if errors.As(err, &exitErr) {
-			if !exitErr.Silent {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", exitErr.Err)
-			}
-			os.Exit(exitErr.Code)
-		}
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
 	}
 }
 

--- a/internal/sso/login.go
+++ b/internal/sso/login.go
@@ -67,11 +67,11 @@ func RunSSOLogin(ctx context.Context, ssoStartURL, ssoRegion, ssoSession string,
 	printAuthorizationInstructions(opts.Output, aws.ToString(auth.VerificationUriComplete), aws.ToString(auth.UserCode), opts.OpenBrowser)
 	if opts.OpenBrowser {
 		if err := opts.BrowserOpener(aws.ToString(auth.VerificationUriComplete)); err != nil {
-			fmt.Fprintf(opts.Output, "Warning: failed to open browser automatically: %v\n\n", err)
+			writef(opts.Output, "Warning: failed to open browser automatically: %v\n\n", err)
 		}
 	}
 
-	fmt.Fprintln(opts.Output, "Waiting for authorization...")
+	writeln(opts.Output, "Waiting for authorization...")
 
 	// Step 4: Poll for token
 	interval := int(auth.Interval)
@@ -114,7 +114,7 @@ func RunSSOLogin(ctx context.Context, ssoStartURL, ssoRegion, ssoSession string,
 			return fmt.Errorf("failed to save token: %w", err)
 		}
 
-		fmt.Fprintln(opts.Output, "\n✓ SSO login successful!")
+		writeln(opts.Output, "\n✓ SSO login successful!")
 		return nil
 	}
 
@@ -161,15 +161,15 @@ func normalizeLoginOptions(opts LoginOptions) LoginOptions {
 
 func printAuthorizationInstructions(w io.Writer, verificationURL, userCode string, openBrowser bool) {
 	if !openBrowser {
-		fmt.Fprintln(w, "Headless mode: browser auto-open disabled.")
+		writeln(w, "Headless mode: browser auto-open disabled.")
 	}
-	fmt.Fprintln(w)
-	fmt.Fprintln(w, "Open the following URL in your browser:")
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  %s\n\n", verificationURL)
-	fmt.Fprintf(w, "Confirmation code: %s\n\n", userCode)
+	writeln(w, "")
+	writeln(w, "Open the following URL in your browser:")
+	writeln(w, "")
+	writef(w, "  %s\n\n", verificationURL)
+	writef(w, "Confirmation code: %s\n\n", userCode)
 	if !openBrowser {
-		fmt.Fprintln(w, "Authorize the device in any browser, then return here.")
+		writeln(w, "Authorize the device in any browser, then return here.")
 	}
 }
 
@@ -177,4 +177,12 @@ func openBrowser(url string) error {
 	// macOS
 	cmd := exec.Command("open", url)
 	return cmd.Start()
+}
+
+func writeln(w io.Writer, args ...any) {
+	_, _ = fmt.Fprintln(w, args...)
+}
+
+func writef(w io.Writer, format string, args ...any) {
+	_, _ = fmt.Fprintf(w, format, args...)
 }

--- a/internal/sso/login.go
+++ b/internal/sso/login.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,12 +17,21 @@ import (
 	ssooidctypes "github.com/aws/aws-sdk-go-v2/service/ssooidc/types"
 )
 
+// LoginOptions controls how the device authorization flow is presented.
+type LoginOptions struct {
+	OpenBrowser   bool
+	Output        io.Writer
+	BrowserOpener func(string) error
+}
+
 // RunSSOLogin performs SSO login using OIDC device authorization flow.
 // This works even without any existing ~/.aws/config profiles.
 // ssoSession is the [sso-session <name>] value from ~/.aws/config; it is used
 // to produce a cache filename that the AWS CLI v2 can locate. Pass "" for
 // legacy (non-sso-session) profiles, in which case the start URL is used.
-func RunSSOLogin(ctx context.Context, ssoStartURL, ssoRegion, ssoSession string) error {
+func RunSSOLogin(ctx context.Context, ssoStartURL, ssoRegion, ssoSession string, opts LoginOptions) error {
+	opts = normalizeLoginOptions(opts)
+
 	cfg, err := awsconfig.LoadDefaultConfig(ctx,
 		awsconfig.WithRegion(ssoRegion),
 		awsconfig.WithCredentialsProvider(aws.AnonymousCredentials{}),
@@ -54,14 +64,14 @@ func RunSSOLogin(ctx context.Context, ssoStartURL, ssoRegion, ssoSession string)
 	}
 
 	// Step 3: Ask user to authorize in browser
-	fmt.Printf("\nOpen the following URL in your browser:\n\n")
-	fmt.Printf("  %s\n\n", aws.ToString(auth.VerificationUriComplete))
-	fmt.Printf("Confirmation code: %s\n\n", aws.ToString(auth.UserCode))
+	printAuthorizationInstructions(opts.Output, aws.ToString(auth.VerificationUriComplete), aws.ToString(auth.UserCode), opts.OpenBrowser)
+	if opts.OpenBrowser {
+		if err := opts.BrowserOpener(aws.ToString(auth.VerificationUriComplete)); err != nil {
+			fmt.Fprintf(opts.Output, "Warning: failed to open browser automatically: %v\n\n", err)
+		}
+	}
 
-	// Try to open browser
-	openBrowser(aws.ToString(auth.VerificationUriComplete))
-
-	fmt.Println("Waiting for authorization...")
+	fmt.Fprintln(opts.Output, "Waiting for authorization...")
 
 	// Step 4: Poll for token
 	interval := int(auth.Interval)
@@ -104,7 +114,7 @@ func RunSSOLogin(ctx context.Context, ssoStartURL, ssoRegion, ssoSession string)
 			return fmt.Errorf("failed to save token: %w", err)
 		}
 
-		fmt.Println("\n✓ SSO login successful!")
+		fmt.Fprintln(opts.Output, "\n✓ SSO login successful!")
 		return nil
 	}
 
@@ -139,8 +149,32 @@ func saveTokenToCache(accessToken string, expiresIn int, startURL, region, ssoSe
 	return os.WriteFile(path, []byte(content), 0600)
 }
 
-func openBrowser(url string) {
+func normalizeLoginOptions(opts LoginOptions) LoginOptions {
+	if opts.Output == nil {
+		opts.Output = os.Stdout
+	}
+	if opts.BrowserOpener == nil {
+		opts.BrowserOpener = openBrowser
+	}
+	return opts
+}
+
+func printAuthorizationInstructions(w io.Writer, verificationURL, userCode string, openBrowser bool) {
+	if !openBrowser {
+		fmt.Fprintln(w, "Headless mode: browser auto-open disabled.")
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Open the following URL in your browser:")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  %s\n\n", verificationURL)
+	fmt.Fprintf(w, "Confirmation code: %s\n\n", userCode)
+	if !openBrowser {
+		fmt.Fprintln(w, "Authorize the device in any browser, then return here.")
+	}
+}
+
+func openBrowser(url string) error {
 	// macOS
 	cmd := exec.Command("open", url)
-	_ = cmd.Start()
+	return cmd.Start()
 }

--- a/internal/sso/login_test.go
+++ b/internal/sso/login_test.go
@@ -1,0 +1,35 @@
+package sso
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPrintAuthorizationInstructions_Headless(t *testing.T) {
+	var out bytes.Buffer
+
+	printAuthorizationInstructions(&out, "https://example.awsapps.com/verify", "ABCD-EFGH", false)
+
+	got := out.String()
+	for _, want := range []string{
+		"Headless mode: browser auto-open disabled.",
+		"https://example.awsapps.com/verify",
+		"Confirmation code: ABCD-EFGH",
+		"Authorize the device in any browser, then return here.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output %q does not contain %q", got, want)
+		}
+	}
+}
+
+func TestNormalizeLoginOptions_Defaults(t *testing.T) {
+	opts := normalizeLoginOptions(LoginOptions{OpenBrowser: true})
+	if opts.Output == nil {
+		t.Fatal("Output was nil")
+	}
+	if opts.BrowserOpener == nil {
+		t.Fatal("BrowserOpener was nil")
+	}
+}


### PR DESCRIPTION
## Summary
- add a global --headless flag to disable browser auto-open during AWS SSO device auth
- propagate headless login behavior through login, use, creds, and sync flows
- add tests and README coverage for the new headless login flow

## Testing
- GOCACHE=/Users/koseisasagawa/Desktop/workspace/ps/aws-sso-login/.gocache GOMODCACHE=/Users/koseisasagawa/Desktop/workspace/ps/aws-sso-login/.gomodcache go test ./...
- GOCACHE=/Users/koseisasagawa/Desktop/workspace/ps/aws-sso-login/.gocache GOMODCACHE=/Users/koseisasagawa/Desktop/workspace/ps/aws-sso-login/.gomodcache go build -o bin/aws-sso-login ./cmd/aws-sso-login
