### PR TITLE
fix(login): persist OIDC refresh token and refresh access token silently

### DIFF
--- a/cmd/aws-sso-login/actions.go
+++ b/cmd/aws-sso-login/actions.go
@@ -243,6 +243,42 @@ func handleUse(ctx context.Context, c *cli.Command) error {
 	return nil
 }
 
+// getCachedToken returns the cached token for startURL, falling back to the
+// latest token in the cache when no start-URL-specific entry exists.
+func getCachedToken(startURL string) (*sso.CachedToken, error) {
+	if startURL != "" {
+		if t, err := sso.GetTokenForStartURL(startURL); err == nil {
+			return t, nil
+		}
+	}
+	return sso.GetLatestToken()
+}
+
+// resolveUsableToken returns a valid SSO token for startURL. It refreshes an
+// expired-but-refreshable token silently. When the token is missing or the
+// refresh fails (e.g. the session itself has expired), it falls back to an
+// interactive browser login when interactive is true, otherwise it errors.
+func resolveUsableToken(ctx context.Context, startURL, ssoRegion, ssoSession string, interactive bool) (*sso.CachedToken, error) {
+	if token, err := getCachedToken(startURL); err == nil {
+		if fresh, rErr := sso.EnsureFreshToken(ctx, token); rErr == nil {
+			return fresh, nil
+		}
+		// Token present but cannot be refreshed (no/expired refresh token) — re-login.
+	}
+	if !interactive {
+		return nil, fmt.Errorf("no valid SSO session. Run 'aws-sso-login login' first")
+	}
+	logInfo("No valid SSO session. Starting login...")
+	if loginErr := sso.RunSSOLogin(ctx, startURL, ssoRegion, ssoSession); loginErr != nil {
+		return nil, fmt.Errorf("SSO login failed: %w", loginErr)
+	}
+	token, err := getCachedToken(startURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get SSO token after login: %w", err)
+	}
+	return token, nil
+}
+
 // --- creds (scoped temporary credentials) ---
 
 func handleCreds(ctx context.Context, c *cli.Command) error {
@@ -266,35 +302,12 @@ func handleCreds(ctx context.Context, c *cli.Command) error {
 	startURL := cfg.ResolveStartURL(profile)
 	ssoRegion := cfg.ResolveRegion(profile)
 
-	// Resolve SSO token
-	var token *sso.CachedToken
-	token, err = sso.GetTokenForStartURL(startURL)
+	// Resolve a usable SSO token: refresh silently when possible, fall back to
+	// interactive login only when refresh is impossible and a TTY is available.
+	interactive := !opts.JSON && c.String("format") != "json"
+	token, err := resolveUsableToken(ctx, startURL, ssoRegion, profile.SSOSession, interactive)
 	if err != nil {
-		token, err = sso.GetLatestToken()
-		if err != nil {
-			if opts.JSON || c.String("format") == "json" {
-				return fmt.Errorf("no valid SSO session. Run 'aws-sso-login login' first")
-			}
-			logInfo("No valid SSO session. Starting login...")
-			if loginErr := sso.RunSSOLogin(ctx, startURL, ssoRegion, profile.SSOSession); loginErr != nil {
-				return fmt.Errorf("SSO login failed: %w", loginErr)
-			}
-			token, err = sso.GetTokenForStartURL(startURL)
-			if err != nil {
-				token, err = sso.GetLatestToken()
-				if err != nil {
-					return fmt.Errorf("failed to get SSO token after login: %w", err)
-				}
-			}
-		} else if token.StartURL != startURL {
-			logInfo("Warning: Using token for %s instead of %s", token.StartURL, startURL)
-		}
-	}
-
-	// Silently refresh an expired access token while the refresh token is alive,
-	// so credential_process works headlessly instead of forcing a browser login.
-	if token, err = sso.EnsureFreshToken(ctx, token); err != nil {
-		return fmt.Errorf("failed to refresh SSO token: %w", err)
+		return err
 	}
 
 	creds, err := sso.GetRoleCredentials(ctx, token.AccessToken, profile.SSOAccountID, profile.SSORoleName, ssoRegion)
@@ -452,37 +465,11 @@ func handleSync(ctx context.Context, c *cli.Command) error {
 		return fmt.Errorf("--sso-start-url is required (e.g., https://your-domain.awsapps.com/start/)")
 	}
 
-	// Resolve SSO token
-	var token *sso.CachedToken
-	var err error
-
-	token, err = sso.GetTokenForStartURL(ssoStartURL)
+	// Resolve a usable SSO token: refresh silently when possible, fall back to
+	// interactive login only when refresh is impossible (never in --json mode).
+	token, err := resolveUsableToken(ctx, ssoStartURL, ssoRegion, ssoSession, !opts.JSON)
 	if err != nil {
-		token, err = sso.GetLatestToken()
-		if err != nil {
-			// In --json mode, never trigger interactive browser login
-			if opts.JSON {
-				return fmt.Errorf("no valid SSO session found. Run 'aws-sso-login login' first")
-			}
-			logInfo("No valid SSO session found. Starting SSO login...")
-			if loginErr := sso.RunSSOLogin(ctx, ssoStartURL, ssoRegion, ssoSession); loginErr != nil {
-				return fmt.Errorf("SSO login failed: %w", loginErr)
-			}
-			token, err = sso.GetTokenForStartURL(ssoStartURL)
-			if err != nil {
-				token, err = sso.GetLatestToken()
-				if err != nil {
-					return fmt.Errorf("failed to get SSO token after login: %w", err)
-				}
-			}
-		} else {
-			logInfo("Warning: Using token for %s instead of %s", token.StartURL, ssoStartURL)
-		}
-	}
-
-	// Refresh silently if the access token is expired but still refreshable.
-	if token, err = sso.EnsureFreshToken(ctx, token); err != nil {
-		return fmt.Errorf("failed to refresh SSO token: %w", err)
+		return err
 	}
 
 	logInfo("Using SSO token (expires: %s)", token.ExpiresAt.Format("2006-01-02 15:04:05"))

--- a/cmd/aws-sso-login/actions.go
+++ b/cmd/aws-sso-login/actions.go
@@ -112,6 +112,11 @@ func handleLogin(ctx context.Context, c *cli.Command) error {
 	// Check if already authenticated (skip when --force is specified)
 	if !c.Bool("force") {
 		if token, err := sso.GetTokenForStartURL(ssoStartURL); err == nil {
+			// Refresh silently when expired but refreshable, so a live session
+			// is reported as authenticated without a browser round-trip.
+			if fresh, refreshErr := sso.EnsureFreshToken(ctx, token); refreshErr == nil {
+				token = fresh
+			}
 			if validateErr := sso.ValidateToken(ctx, token.AccessToken, ssoRegion); validateErr == nil {
 				if opts.JSON {
 					return emitJSON(LoginResult{
@@ -284,6 +289,12 @@ func handleCreds(ctx context.Context, c *cli.Command) error {
 		} else if token.StartURL != startURL {
 			logInfo("Warning: Using token for %s instead of %s", token.StartURL, startURL)
 		}
+	}
+
+	// Silently refresh an expired access token while the refresh token is alive,
+	// so credential_process works headlessly instead of forcing a browser login.
+	if token, err = sso.EnsureFreshToken(ctx, token); err != nil {
+		return fmt.Errorf("failed to refresh SSO token: %w", err)
 	}
 
 	creds, err := sso.GetRoleCredentials(ctx, token.AccessToken, profile.SSOAccountID, profile.SSORoleName, ssoRegion)
@@ -467,6 +478,11 @@ func handleSync(ctx context.Context, c *cli.Command) error {
 		} else {
 			logInfo("Warning: Using token for %s instead of %s", token.StartURL, ssoStartURL)
 		}
+	}
+
+	// Refresh silently if the access token is expired but still refreshable.
+	if token, err = sso.EnsureFreshToken(ctx, token); err != nil {
+		return fmt.Errorf("failed to refresh SSO token: %w", err)
 	}
 
 	logInfo("Using SSO token (expires: %s)", token.ExpiresAt.Format("2006-01-02 15:04:05"))

--- a/internal/sso/login.go
+++ b/internal/sso/login.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -99,8 +97,20 @@ func RunSSOLogin(ctx context.Context, ssoStartURL, ssoRegion, ssoSession string)
 			return fmt.Errorf("create token failed: %w", err)
 		}
 
-		// Save token to SSO cache (compatible with AWS CLI)
-		if err := saveTokenToCache(aws.ToString(token.AccessToken), int(token.ExpiresIn), ssoStartURL, ssoRegion, ssoSession); err != nil {
+		// Save token to SSO cache (compatible with AWS CLI v2). Persist the
+		// refresh token and client registration so the access token can be
+		// refreshed silently later instead of forcing an interactive re-login.
+		cached := &CachedToken{
+			AccessToken:           aws.ToString(token.AccessToken),
+			RefreshToken:          aws.ToString(token.RefreshToken),
+			ClientID:              aws.ToString(reg.ClientId),
+			ClientSecret:          aws.ToString(reg.ClientSecret),
+			RegistrationExpiresAt: time.Unix(reg.ClientSecretExpiresAt, 0).UTC(),
+			ExpiresAt:             time.Now().Add(time.Duration(token.ExpiresIn) * time.Second),
+			StartURL:              ssoStartURL,
+			Region:                ssoRegion,
+		}
+		if err := saveTokenToCache(cached, ssoSession); err != nil {
 			return fmt.Errorf("failed to save token: %w", err)
 		}
 
@@ -111,20 +121,11 @@ func RunSSOLogin(ctx context.Context, ssoStartURL, ssoRegion, ssoSession string)
 	return fmt.Errorf("authorization timed out. Please try again")
 }
 
-func saveTokenToCache(accessToken string, expiresIn int, startURL, region, ssoSession string) error {
-	expiresAt := time.Now().Add(time.Duration(expiresIn) * time.Second)
-
-	// Build JSON manually to stay compatible with AWS CLI cache format
-	content := fmt.Sprintf(`{
-  "accessToken": %q,
-  "expiresAt": %q,
-  "startUrl": %q,
-  "region": %q
-}`, accessToken, expiresAt.UTC().Format(time.RFC3339), startURL, region)
-
-	// Use the SDK's StandardCachedTokenFilepath to compute the correct path.
-	// sso-session style: sha1(session_name); legacy: sha1(startUrl).
-	cacheKey := startURL
+// saveTokenToCache writes the token to the AWS CLI v2 cache location. The path
+// is derived from the sso-session name (sha1(session_name)) or, for legacy
+// profiles, the start URL (sha1(startUrl)).
+func saveTokenToCache(token *CachedToken, ssoSession string) error {
+	cacheKey := token.StartURL
 	if ssoSession != "" {
 		cacheKey = ssoSession
 	}
@@ -132,11 +133,8 @@ func saveTokenToCache(accessToken string, expiresIn int, startURL, region, ssoSe
 	if err != nil {
 		return fmt.Errorf("failed to determine token cache path: %w", err)
 	}
-
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		return err
-	}
-	return os.WriteFile(path, []byte(content), 0600)
+	token.FilePath = path
+	return writeTokenCache(token)
 }
 
 func openBrowser(url string) {

--- a/internal/sso/token.go
+++ b/internal/sso/token.go
@@ -1,24 +1,150 @@
 package sso
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
 )
 
-// CachedToken represents a cached SSO token
+// refreshSkew is how long before the access token's expiry we proactively refresh.
+const refreshSkew = 5 * time.Minute
+
+// ErrRefreshUnavailable is returned when a token is expired but cannot be
+// refreshed (no refresh token, or the client registration itself has expired).
+// Callers should fall back to an interactive login.
+var ErrRefreshUnavailable = errors.New("SSO token expired and cannot be refreshed")
+
+// CachedToken represents a cached SSO token in the AWS CLI v2 cache format.
 type CachedToken struct {
-	AccessToken string    `json:"accessToken"`
-	ExpiresAt   time.Time `json:"expiresAt"`
-	StartURL    string    `json:"startUrl"`
-	Region      string    `json:"region"`
-	FilePath    string    `json:"-"`
+	AccessToken           string    `json:"accessToken"`
+	RefreshToken          string    `json:"refreshToken,omitempty"`
+	ClientID              string    `json:"clientId,omitempty"`
+	ClientSecret          string    `json:"clientSecret,omitempty"`
+	RegistrationExpiresAt time.Time `json:"registrationExpiresAt,omitempty"`
+	ExpiresAt             time.Time `json:"expiresAt"`
+	StartURL              string    `json:"startUrl"`
+	Region                string    `json:"region"`
+	FilePath              string    `json:"-"`
 }
 
-// GetLatestToken retrieves the latest valid SSO token from cache
+// NeedsRefresh reports whether the access token is at or past its expiry,
+// within a small skew window, and should be refreshed before use.
+func (t *CachedToken) NeedsRefresh(now time.Time) bool {
+	return !now.Add(refreshSkew).Before(t.ExpiresAt)
+}
+
+// CanRefresh reports whether a silent refresh is possible: a refresh token and
+// client registration must be present, and the registration must not be expired.
+func (t *CachedToken) CanRefresh(now time.Time) bool {
+	if t.RefreshToken == "" || t.ClientID == "" || t.ClientSecret == "" {
+		return false
+	}
+	return t.RegistrationExpiresAt.IsZero() || now.Before(t.RegistrationExpiresAt)
+}
+
+// marshalCache renders the token in the AWS CLI v2 cache JSON layout. Optional
+// fields are omitted when empty so registration-only entries stay clean.
+func (t *CachedToken) marshalCache() ([]byte, error) {
+	type cacheJSON struct {
+		StartURL              string `json:"startUrl,omitempty"`
+		Region                string `json:"region,omitempty"`
+		AccessToken           string `json:"accessToken"`
+		ExpiresAt             string `json:"expiresAt"`
+		ClientID              string `json:"clientId,omitempty"`
+		ClientSecret          string `json:"clientSecret,omitempty"`
+		RegistrationExpiresAt string `json:"registrationExpiresAt,omitempty"`
+		RefreshToken          string `json:"refreshToken,omitempty"`
+	}
+	c := cacheJSON{
+		StartURL:     t.StartURL,
+		Region:       t.Region,
+		AccessToken:  t.AccessToken,
+		ExpiresAt:    t.ExpiresAt.UTC().Format(time.RFC3339),
+		ClientID:     t.ClientID,
+		ClientSecret: t.ClientSecret,
+		RefreshToken: t.RefreshToken,
+	}
+	if !t.RegistrationExpiresAt.IsZero() {
+		c.RegistrationExpiresAt = t.RegistrationExpiresAt.UTC().Format(time.RFC3339)
+	}
+	return json.MarshalIndent(c, "", "  ")
+}
+
+// writeTokenCache persists the token to its FilePath in AWS CLI v2 format.
+func writeTokenCache(t *CachedToken) error {
+	if t.FilePath == "" {
+		return fmt.Errorf("token cache file path is empty")
+	}
+	data, err := t.marshalCache()
+	if err != nil {
+		return fmt.Errorf("failed to marshal token cache: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(t.FilePath), 0700); err != nil {
+		return err
+	}
+	return os.WriteFile(t.FilePath, data, 0600)
+}
+
+// EnsureFreshToken returns a usable token: the input unchanged when still valid,
+// a silently refreshed token when expired but refreshable, or ErrRefreshUnavailable
+// when refresh is impossible (caller should re-login interactively).
+func EnsureFreshToken(ctx context.Context, t *CachedToken) (*CachedToken, error) {
+	now := time.Now()
+	if !t.NeedsRefresh(now) {
+		return t, nil
+	}
+	if !t.CanRefresh(now) {
+		return nil, ErrRefreshUnavailable
+	}
+	return RefreshAccessToken(ctx, t)
+}
+
+// RefreshAccessToken exchanges the refresh token for a new access token via the
+// OIDC refresh_token grant and persists the rotated token back to the cache file.
+func RefreshAccessToken(ctx context.Context, t *CachedToken) (*CachedToken, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion(t.Region),
+		awsconfig.WithCredentialsProvider(aws.AnonymousCredentials{}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AWS config: %w", err)
+	}
+
+	oidc := ssooidc.NewFromConfig(cfg)
+	out, err := oidc.CreateToken(ctx, &ssooidc.CreateTokenInput{
+		ClientId:     &t.ClientID,
+		ClientSecret: &t.ClientSecret,
+		GrantType:    aws.String("refresh_token"),
+		RefreshToken: &t.RefreshToken,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("token refresh failed: %w", err)
+	}
+
+	updated := *t
+	updated.AccessToken = aws.ToString(out.AccessToken)
+	updated.ExpiresAt = time.Now().Add(time.Duration(out.ExpiresIn) * time.Second)
+	// The refresh token may be rotated; keep the existing one when none is returned.
+	if rt := aws.ToString(out.RefreshToken); rt != "" {
+		updated.RefreshToken = rt
+	}
+	if err := writeTokenCache(&updated); err != nil {
+		return nil, fmt.Errorf("failed to persist refreshed token: %w", err)
+	}
+	return &updated, nil
+}
+
+// GetLatestToken retrieves the latest usable SSO token from cache. A token is
+// usable when it is still valid, or expired but refreshable.
 func GetLatestToken() (*CachedToken, error) {
 	cacheDir := filepath.Join(os.Getenv("HOME"), ".aws", "sso", "cache")
 
@@ -50,8 +176,9 @@ func GetLatestToken() (*CachedToken, error) {
 			continue
 		}
 
-		// Skip expired tokens
-		if time.Now().After(token.ExpiresAt) {
+		// Skip tokens that are expired AND cannot be refreshed.
+		now := time.Now()
+		if now.After(token.ExpiresAt) && !token.CanRefresh(now) {
 			continue
 		}
 
@@ -71,7 +198,8 @@ func GetLatestToken() (*CachedToken, error) {
 	return tokens[0], nil
 }
 
-// GetTokenForStartURL retrieves SSO token for specific start URL
+// GetTokenForStartURL retrieves the SSO token for a specific start URL. A token
+// is eligible when it is still valid, or expired but refreshable.
 func GetTokenForStartURL(startURL string) (*CachedToken, error) {
 	cacheDir := filepath.Join(os.Getenv("HOME"), ".aws", "sso", "cache")
 
@@ -102,7 +230,8 @@ func GetTokenForStartURL(startURL string) (*CachedToken, error) {
 		if token.StartURL != startURL || token.AccessToken == "" {
 			continue
 		}
-		if time.Now().After(token.ExpiresAt) {
+		now := time.Now()
+		if now.After(token.ExpiresAt) && !token.CanRefresh(now) {
 			foundExpired = true
 			continue
 		}

--- a/internal/sso/token_test.go
+++ b/internal/sso/token_test.go
@@ -1,0 +1,199 @@
+package sso
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNeedsRefresh(t *testing.T) {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		expiresIn time.Duration
+		want      bool
+	}{
+		{"valid well ahead", 30 * time.Minute, false},
+		{"just outside skew", 6 * time.Minute, false},
+		{"inside skew window", 3 * time.Minute, true},
+		{"already expired", -1 * time.Minute, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tok := &CachedToken{ExpiresAt: now.Add(tt.expiresIn)}
+			if got := tok.NeedsRefresh(now); got != tt.want {
+				t.Errorf("NeedsRefresh = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCanRefresh(t *testing.T) {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	full := func() *CachedToken {
+		return &CachedToken{
+			RefreshToken:          "rt",
+			ClientID:              "cid",
+			ClientSecret:          "secret",
+			RegistrationExpiresAt: now.Add(24 * time.Hour),
+		}
+	}
+	tests := []struct {
+		name   string
+		mutate func(*CachedToken)
+		want   bool
+	}{
+		{"complete and registration valid", func(*CachedToken) {}, true},
+		{"registration unset (zero) still ok", func(c *CachedToken) { c.RegistrationExpiresAt = time.Time{} }, true},
+		{"no refresh token", func(c *CachedToken) { c.RefreshToken = "" }, false},
+		{"no client id", func(c *CachedToken) { c.ClientID = "" }, false},
+		{"no client secret", func(c *CachedToken) { c.ClientSecret = "" }, false},
+		{"registration expired", func(c *CachedToken) { c.RegistrationExpiresAt = now.Add(-time.Hour) }, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tok := full()
+			tt.mutate(tok)
+			if got := tok.CanRefresh(now); got != tt.want {
+				t.Errorf("CanRefresh = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCacheRoundTrip verifies the cache JSON is AWS CLI v2-compatible: all
+// fields survive a marshal/unmarshal cycle and the standard keys are present.
+func TestCacheRoundTrip(t *testing.T) {
+	orig := &CachedToken{
+		AccessToken:           "access",
+		RefreshToken:          "refresh",
+		ClientID:              "client-id",
+		ClientSecret:          "client-secret",
+		RegistrationExpiresAt: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+		ExpiresAt:             time.Date(2026, 6, 11, 13, 0, 0, 0, time.UTC),
+		StartURL:              "https://example.awsapps.com/start/",
+		Region:                "ap-northeast-1",
+	}
+
+	data, err := orig.marshalCache()
+	if err != nil {
+		t.Fatalf("marshalCache: %v", err)
+	}
+
+	var keys map[string]json.RawMessage
+	if err := json.Unmarshal(data, &keys); err != nil {
+		t.Fatalf("unmarshal to keys: %v", err)
+	}
+	for _, k := range []string{"accessToken", "refreshToken", "clientId", "clientSecret", "registrationExpiresAt", "expiresAt", "startUrl", "region"} {
+		if _, ok := keys[k]; !ok {
+			t.Errorf("cache JSON missing key %q", k)
+		}
+	}
+
+	var got CachedToken
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal to token: %v", err)
+	}
+	if got.AccessToken != orig.AccessToken || got.RefreshToken != orig.RefreshToken ||
+		got.ClientID != orig.ClientID || got.ClientSecret != orig.ClientSecret ||
+		got.StartURL != orig.StartURL || got.Region != orig.Region {
+		t.Errorf("string fields not preserved: %+v", got)
+	}
+	if !got.ExpiresAt.Equal(orig.ExpiresAt) {
+		t.Errorf("ExpiresAt = %v, want %v", got.ExpiresAt, orig.ExpiresAt)
+	}
+	if !got.RegistrationExpiresAt.Equal(orig.RegistrationExpiresAt) {
+		t.Errorf("RegistrationExpiresAt = %v, want %v", got.RegistrationExpiresAt, orig.RegistrationExpiresAt)
+	}
+}
+
+// TestCacheRoundTripOmitsEmptyOptionalFields ensures registration-only / legacy
+// entries do not get empty optional keys written.
+func TestCacheRoundTripOmitsEmptyOptionalFields(t *testing.T) {
+	tok := &CachedToken{
+		AccessToken: "access",
+		ExpiresAt:   time.Date(2026, 6, 11, 13, 0, 0, 0, time.UTC),
+		StartURL:    "https://example.awsapps.com/start/",
+		Region:      "ap-northeast-1",
+	}
+	data, err := tok.marshalCache()
+	if err != nil {
+		t.Fatalf("marshalCache: %v", err)
+	}
+	var keys map[string]json.RawMessage
+	if err := json.Unmarshal(data, &keys); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"refreshToken", "clientId", "clientSecret", "registrationExpiresAt"} {
+		if _, ok := keys[k]; ok {
+			t.Errorf("expected optional key %q to be omitted when empty", k)
+		}
+	}
+}
+
+// TestGetLatestTokenRetainsRefreshable verifies the reader keeps an expired but
+// refreshable token, and skips an expired non-refreshable one.
+func TestGetLatestTokenRetainsRefreshable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cacheDir := filepath.Join(home, ".aws", "sso", "cache")
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	write := func(name string, tok *CachedToken) {
+		data, err := tok.marshalCache()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(cacheDir, name), data, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	now := time.Now()
+
+	t.Run("expired but refreshable is returned", func(t *testing.T) {
+		write("refreshable.json", &CachedToken{
+			AccessToken:           "stale",
+			RefreshToken:          "rt",
+			ClientID:              "cid",
+			ClientSecret:          "secret",
+			RegistrationExpiresAt: now.Add(24 * time.Hour),
+			ExpiresAt:             now.Add(-10 * time.Minute),
+			StartURL:              "https://example.awsapps.com/start/",
+			Region:                "ap-northeast-1",
+		})
+		got, err := GetLatestToken()
+		if err != nil {
+			t.Fatalf("GetLatestToken: %v", err)
+		}
+		if got.AccessToken != "stale" {
+			t.Errorf("expected refreshable token to be returned, got %+v", got)
+		}
+	})
+
+	t.Run("expired non-refreshable is skipped", func(t *testing.T) {
+		empty := t.TempDir()
+		t.Setenv("HOME", empty)
+		dir := filepath.Join(empty, ".aws", "sso", "cache")
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		tok := &CachedToken{
+			AccessToken: "stale",
+			ExpiresAt:   now.Add(-10 * time.Minute),
+			StartURL:    "https://example.awsapps.com/start/",
+			Region:      "ap-northeast-1",
+		}
+		data, _ := tok.marshalCache()
+		if err := os.WriteFile(filepath.Join(dir, "stale.json"), data, 0600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := GetLatestToken(); err == nil {
+			t.Error("expected error when only an expired non-refreshable token exists")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes the "re-authentication required ~every hour" behaviour by persisting the OIDC **refresh token** (and client registration) and refreshing the SSO access token silently, restoring parity with the native AWS CLI v2.

Root cause and full investigation: #20.

### What changed
- **Persist the full AWS CLI v2 token cache** in `saveTokenToCache`: `refreshToken`, `clientId`, `clientSecret`, `registrationExpiresAt` alongside the existing fields. The cache is now refreshable by this tool *and* the native `aws` CLI.
- **Silent refresh** (`EnsureFreshToken` / `RefreshAccessToken` in `internal/sso/token.go`): when the access token is expired (or within a 5‑min skew) but a valid refresh token + registration exist, exchange it via the `refresh_token` grant and persist the rotated token — no browser.
- **Readers retain refreshable-expired tokens** so refresh can happen; truly-unrefreshable expired tokens are still skipped.
- **Centralized token resolution** (`resolveUsableToken`) used by `creds` / `sync`: refresh silently when possible, fall back to interactive login (or a clean error in `--json` / credential_process mode) when refresh is impossible. `login` refreshes silently before reporting "already authenticated".

### Non-goals
- Does not change the true browser re-auth boundary (IdC **session duration** = refresh-token lifetime, server-side).
- Access-token (~1h) and role-credential (~4h) lifetimes are server-decided and unchanged.

## Test plan (verified)

- [x] `go build ./...` / `go vet ./...` clean; `golangci-lint run ./...` → **0 issues**; `go test ./...` passes (incl. new `internal/sso/token_test.go`)
- [x] Unit: `NeedsRefresh` / `CanRefresh`, cache JSON round-trip (+ omits empty optional keys), reader retains refreshable / skips non-refreshable
- [x] **Happy path — silent refresh against a real cache** (access token expired by 78 min, refresh token alive):
  - BEFORE `expiresAt=2026-06-11T06:42:43Z` → `creds --format json` exit 0, valid creds, **no browser** → AFTER `expiresAt=2026-06-11T09:01:06Z`, access token refreshed & persisted
- [x] **AWS CLI v2 interop**: tool-rewritten cache has all standard keys; native `aws sts get-caller-identity` succeeds against the same file
- [x] **Expired-session boundary** (refresh token itself expired, ~22h old): refresh returns `InvalidGrantException`. This surfaced a regression — the interactive-login fallback no longer triggered because readers retain refreshable-expired tokens. **Fixed** by centralizing resolution in `resolveUsableToken`. Re-verified: in `--json` mode a dead session now returns a clean `no valid SSO session. Run 'aws-sso-login login' first` (no raw `InvalidGrantException`, no browser).
- [x] **Value-level proof with the final binary** (fresh device-flow login, then access token force-expired): `creds` exit 0, **no browser**, and the cached `accessToken` value changed (sha256 `23fee4f0…` → `4b029ee9…`) with `expiresAt` advanced ~1h — i.e. a genuinely new access token was minted via `refresh_token`, persisted, full keys retained, and native `aws` still works against the same cache.

Closes #20
